### PR TITLE
Lighten up links and table of contents selections in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,9 +24,14 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
+.table-of-contents__link--active {
+  font-weight: 500;
+}
+
 /* Change Infima theme colors in dark mode */
 html[data-theme='dark'] {
-  --ifm-link-color: #A20292;
+  --ifm-color-primary: #CA02B6;
+  --ifm-link-color: #CA02B6;
 }
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {


### PR DESCRIPTION
Resolves #2

- Uses lighter primary color for links and toc links
- Also makes toc selection a bit bolder for light mode