### PR TITLE
Fix path checking between operating systems

### DIFF
--- a/tasks/get-languages.js
+++ b/tasks/get-languages.js
@@ -50,7 +50,7 @@ function makeLanguage(languagePath) {
 
   // find language info
   const infoPath = path.join(languagePath, categoryFileName);
-  const rawPath = languagePath.split(/\\/).slice(-1)[0];
+  const rawPath = languagePath.split(/[\/|\\]/).slice(-1)[0];
 
   /** @type {{label: string}} */
   const { label } = JSON.parse(fs.readFileSync(infoPath));

--- a/tasks/get-languages.js
+++ b/tasks/get-languages.js
@@ -50,7 +50,7 @@ function makeLanguage(languagePath) {
 
   // find language info
   const infoPath = path.join(languagePath, categoryFileName);
-  const rawPath = languagePath.split(/[\/|\\]/).slice(-1)[0];
+  const rawPath = languagePath.split(/[\/|\\]/g).slice(-1)[0];
 
   /** @type {{label: string}} */
   const { label } = JSON.parse(fs.readFileSync(infoPath));


### PR DESCRIPTION
Here's a fun one. Looks like the path directory checking we were using returns different slashes between operating systems. We were using a regex here that only fits the format for Windows. By making this an OR, this should now also work on MacOS and Linux machines.