### PR TITLE
String definition updates

### DIFF
--- a/docs/javascript/data-types/string.md
+++ b/docs/javascript/data-types/string.md
@@ -6,29 +6,32 @@ sidebar_position: 1
 
 ## Beginner
 
-A sequence of characters
+A sequence of characters, like "Devtionary". Strings are written with quotes.
 
 ## Intermediate
 
-A primitive
-
-Translate `i18n/fr/docusaurus-plugin-content-docs/current/intro.md` in French.
+The `String` object is used to represent and manipulate a sequence of characters.
 
 ## Advanced
 
+Strings hold data that can be represented in text form. They can be created as primitives, from string literals or as objects.
 
 ## Examples
 
 ### In Code
+
 ```js
-const string = "this is a string"
+const string = 'this is a string';
 ```
 
 ### In Conversation
-> I concatenated a string on accident using a number!
 
+> I concatenated a string on accident using a number!
 
 ## Stack Overflow Answers
 
-
 ## Video Explainer
+
+<a class="youtube-link" href="https://www.youtube.com/watch?v=09BwruU4kiY" target="_blank" title="Watch on YouTube">
+  <img alt="JavaScript Strings - Programming with Mosh" src="http://i3.ytimg.com/vi/09BwruU4kiY/maxresdefault.jpg"/>
+</a>

--- a/src/components/HomepageLanguages.js
+++ b/src/components/HomepageLanguages.js
@@ -37,11 +37,9 @@ export default () => {
           <Link to='docs/what-is-devtionary'>See All &raquo;</Link>
         </div>
       </div>
-      <div className='row'>{
-        LanguageList
-          .sort((a, b) => b.defs - a.defs)
-          .map(Language)
-      }</div>
+      <div className='row'>
+        {LanguageList.map(Language)}
+      </div>
     </div>
   );
 };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -65,3 +65,50 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   display: flex;
   flex-direction: column;
 }
+
+/* Youtube link styles */
+.youtube-link {
+  display: block;
+  position: relative;
+}
+
+.youtube-link img {
+  transition: all 0.2s ease;
+}
+
+.youtube-link::before,
+.youtube-link::after {
+  opacity: 0;
+  content: '';
+  font-size: 2.5em;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transition: all 0.2s ease;
+}
+
+.youtube-link::before {
+  width: 0;
+  height: 0;
+  z-index: 2;
+  border-style: solid;
+  border-width: 1em 0 1em 1.73em;
+  border-color: transparent transparent transparent #fff;
+}
+
+.youtube-link::after {
+  height: 3.5em;
+  width: 5.5em;
+  background: #ff0000;
+  border-radius: 3vw;
+}
+
+.youtube-link:hover::before,
+.youtube-link:hover::after {
+  opacity: 1;
+}
+
+.youtube-link:hover img {
+  opacity: 0.5;
+}

--- a/tasks/get-languages.js
+++ b/tasks/get-languages.js
@@ -36,6 +36,8 @@ function readLanguages(currentPath) {
     }
   });
 
+  // sort languages by number of definitions
+  results.sort((langA, langB) => langB.defs - langA.defs);
   return results;
 }
 


### PR DESCRIPTION
- Clean up definition for `JavaScript > Data Types > String`
- Add styles for YouTube links included in video explainers. For future reference, the markup for these is as follows:

```html
<a class="youtube-link" href="link/to/youtube" target="_blank" title="Watch on YouTube">
  <img alt="Video Title" src="link/to/thumbnail" />
</a>
```