### PR TITLE
Create partial mdx files for shared link components

### DIFF
--- a/docs/_external-link.mdx
+++ b/docs/_external-link.mdx
@@ -1,0 +1,3 @@
+<a href={props.href} target='_blank' rel='noopenner noreferrer' title={props.title}>
+  {props.label}
+</a>

--- a/docs/_youtube-embed.mdx
+++ b/docs/_youtube-embed.mdx
@@ -1,0 +1,3 @@
+<a class='youtube-link' href={props.href} target='_blank' title='Watch on YouTube'>
+  <img alt={props.alt} src={props.src} />
+</a>

--- a/docs/example.md.example
+++ b/docs/example.md.example
@@ -80,9 +80,14 @@ Information here is not required - but is recommended.
 :::
 
 ### Video Explainer
-<a class="youtube-link" href="https://www.youtube.com/watch?v=09BwruU4kiY" target="_blank" title="Watch on YouTube">
-  <img alt="JavaScript Strings - Programming with Mosh" src="https://i3.ytimg.com/vi/09BwruU4kiY/maxresdefault.jpg"/>
-</a>
+
+import YoutubeEmbed from './_youtube-embed.mdx';
+
+<YoutubeEmbed
+  href='https://www.youtube.com/watch?v=09BwruU4kiY'
+  alt='JavaScript Strings - Programming with Mosh'
+  src='https://i3.ytimg.com/vi/09BwruU4kiY/maxresdefault.jpg'
+/>
 
 ### Links
 

--- a/docs/javascript/data-types/string.mdx
+++ b/docs/javascript/data-types/string.mdx
@@ -1,5 +1,7 @@
 # String
+
 ---
+
 ## Beginner
 
 A sequence of characters, like "Devtionary." Strings are written with quotes.
@@ -9,6 +11,7 @@ A simple string can be created by using double quotes (`"`) or single quotes (`'
 Strings can also include numeric characters (1, 2, 100) and symbols (!@#).
 
 ---
+
 ## Intermediate
 
 Strings hold data that can be represented in text form. They can be created as primitives, from string literals or as objects.
@@ -16,11 +19,13 @@ Strings hold data that can be represented in text form. They can be created as p
 Extra care should be taken when working with string and number data types together, as unexpected behaviors can occur.
 
 ---
+
 ## Advanced
 
 `String` objects and `String` primitives are quite similar in JavaScript and can usually be used interchangeably. There are situations in which differences will be found. However, these disparities are minimal.
 
 ---
+
 ## Examples
 
 ### In Code
@@ -34,14 +39,25 @@ const string = 'this is a string';
 > A Javsacript string is much like text on a billboard, the lines of a book, or anywhere or else that you can read some text characters!
 
 ---
+
 ## Resources for More Info
 
 ### Video Explainer
 
-<a class="youtube-link" href="https://www.youtube.com/watch?v=09BwruU4kiY" target="_blank" title="Watch on YouTube">
-  <img alt="JavaScript Strings - Programming with Mosh" src="https://i3.ytimg.com/vi/09BwruU4kiY/maxresdefault.jpg"/>
-</a>
+import YoutubeEmbed from '../../_youtube-embed.mdx';
+import ExternalLink from '../../_external-link.mdx';
+
+<YoutubeEmbed
+  href='https://www.youtube.com/watch?v=09BwruU4kiY'
+  alt='JavaScript Strings - Programming with Mosh'
+  src='https://i3.ytimg.com/vi/09BwruU4kiY/maxresdefault.jpg'
+/>
 
 ### Links
 
-<div><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String" target="_blank" rel="noopener noreferrer">MDN - String</a></div>
+<div>
+  <ExternalLink
+    href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'
+    label='MDN - String'
+  />
+</div>


### PR DESCRIPTION
Resolves #37
Resolves #38

Imports can't be at the top of the file because docusaurus flips out and doesn't take the title of the mdx file as the title for the sidebar link.